### PR TITLE
docs: add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -57,4 +57,4 @@ Any gliff.ai team members who do not follow or enforce the Code of Conduct in go
 [{{back to navigation}}](#table-of-contents)
 
 Have a question? 🧠 Want to report something? 🚨 \
-Reach out to the gliff.ai team at [contact@gliff.ai](mailto:contact@gliff.ai?subject=[GitHub%20-%20Conduct]) or on GitHub.
+Reach out to the gliff.ai team at [community@gliff.ai](mailto:community@gliff.ai?subject=[GitHub%20-%20Conduct]) or on GitHub.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,7 +10,7 @@ Looking for something specific? 🔍
 
 - [Introduction](#gliffai-code-of-conduct)
 - [Our Standards](#our-standards)
-- [Our Responsibilities](#our-responsibilities)
+- [Our Responsibilities](#our-responsibilites)
 - [Enforcement](#enforcement)
 - [Contact](#contact)
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,11 @@
 
 ⚠️ **All projects and contributors are governed by this document!** ⚠️
 
-The purpose of this guide is to ensure all contributors and projects within the [gliff.ai](https://gliff.ai) space have a unified Code of Conduct to create a positive and welcoming environment for all.
+The purpose of this guide is to outline [gliff.ai](https://gliff.ai)'s expectations of individuals involved in [gliff.ai](https://gliff.ai) activities. While incidents of unaccpetable behaviour are relatively infrequent, this document serves as a guide to form a clear set of standards to maintain a safe and welcoming space that avoids/prevents behaviours that prevent this, while outlining reporting and disciplinary processes.
+
+[gliff.ai](https://gliff.ai) employees a team of passionate and innovative backgrounds, with the outlook that our compnay, our products and our customers benefit from diveristy of backgrounds and perspectives. We prioritise creating a space which is a safe and welcoming environment for all, regardless of their personal identity or background, as anything other than thise can jeopardise the ability to work and with [gliff.ai](https://gliff.ai).
+
+The [gliff.ai Code of Conduct](https://github.com/gliff-ai/.github/blob/main/CODE_OF_CONDUCT.md) ⚠️ **DOES NOT** replace existing legal mechanisms.
 
 ## Table of Contents
 
@@ -48,7 +52,7 @@ Ultimately, the gliff.ai team have the right and responsibility to remove, edit,
 
 [{{back to navigation}}](#table-of-contents)
 
-If you come across any instances of abusive, harassing, or otherwise unacceptable behavior you should report it by contacting the gliff.ai team at at [community@gliff.ai](mailto:community@gliff.ai?subject=[GitHub%20-%20Conduct]) or on GitHub. Any complaints will be reviewed and investigated as part of our pledge to protect our positive and welcoming environment. As such, we will always maintain confidentiality with regards to the reporter of an incident. Any response given will be considered necessary and appropriate to the report raised to the team.
+If you come across any instances of abusive, harassing, or otherwise unacceptable behavior you should report it by contacting the gliff.ai team at at [community@gliff.ai](mailto:community@gliff.ai?subject=[GitHub%20-%20Conduct%20Report]) or on GitHub. Any complaints will be reviewed and investigated as part of our pledge to protect our positive and welcoming environment. As such, we will always maintain confidentiality with regards to the reporter of an incident. Any response given will be considered necessary and appropriate to the report raised to the team.
 
 Any gliff.ai team members who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions. This will be judged and a response will be determined by other members of the gliff.ai team leadership.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,15 +2,16 @@
 
 ⚠️ **All projects and contributors are governed by this document!** ⚠️
 
-The purpose of this guide is to outline [gliff.ai](https://gliff.ai)'s expectations of individuals involved in [gliff.ai](https://gliff.ai) activities. While incidents of unaccpetable behaviour are relatively infrequent, this document serves as a guide to form a clear set of standards to maintain a safe and welcoming space that avoids/prevents behaviours that prevent this, while outlining reporting and disciplinary processes.
+The purpose of this guide is to outline [gliff.ai](https://gliff.ai)'s expectations of individuals involved in [gliff.ai](https://gliff.ai) activities. While incidents of unacceptable behaviour are relatively infrequent, this document serves as a guide to form a clear set of standards to maintain a safe and welcoming space that avoids/prevents behaviours that prevent this, while outlining reporting and disciplinary processes.
 
-[gliff.ai](https://gliff.ai) employees a team of passionate and innovative backgrounds, with the outlook that our compnay, our products and our customers benefit from diveristy of backgrounds and perspectives. We prioritise creating a space which is a safe and welcoming environment for all, regardless of their personal identity or background, as anything other than thise can jeopardise the ability to work and with [gliff.ai](https://gliff.ai).
+[gliff.ai](https://gliff.ai) employees a team of passionate and innovative individuals from various backgrounds, with the outlook that our company, our products and our customers benefit from diversity of backgrounds and perspectives. We prioritise creating a space which is a safe and welcoming environment for all, regardless of their personal identity or background, as anything other than this can jeopardise the ability to work and with [gliff.ai](https://gliff.ai).
 
 ## Table of Contents
 
 Looking for something specific? 🔍
 
 - [Introduction](#gliffai-code-of-conduct)
+- [Table of Contents](#table-of-contents)
 - [Our Standards](#our-standards)
 - [Our Responsibilities](#our-responsibilites)
 - [Enforcement](#enforcement)
@@ -22,7 +23,7 @@ Looking for something specific? 🔍
 
 gliff.ai understands that, in upsetting or distressing circumstances, and in certain forms or stages of ill health, people may act out of character and may become persistent, angry or upset. However, where it leads to aggressive behaviour or unreasonable demands, it is considered unacceptable. Similarly, behaviour which disrupts normal gliff.ai activities, intentionally or not, is considered unacceptable. gliff.ai considers that all forms of harassment constitute unacceptable behaviour.
 
-We have put together some examples of behavior that contributes to creating a positive and welcoming environment, these include:
+We have put together some examples of behaviour that contributes to creating a positive and welcoming environment, these include:
 
 - Using welcoming and inclusive language;
 - Being respectful of differing viewpoints, experiences and skill/ability levels;
@@ -30,12 +31,12 @@ We have put together some examples of behavior that contributes to creating a po
 - Focusing on what is best for the community and users;
 - Showing empathy and respect towards other community members.
 
-We have also put together some examples of unacceptable behavior, these include:
+We have also put together some examples of unacceptable behaviour, these include:
 
 - The use of sexualized language or imagery and unwelcome sexual attention or advances;
-- Comments that reinforce social structures of domination and/or discrimination realted to gender, gender identity and expression, sexual orientation, ability, physical appear, race and ethnicity, religion and believe or other ireelevant distinctions;
+- Comments that reinforce social structures of domination and/or discrimination related to gender, gender identity and expression, sexual orientation, ability, physical appear, race and ethnicity, religion and believe or other irrelevant distinctions;
 - Trolling, spamming, insulting/derogatory comments, and personal or political attacks;
-- Public or private harassment, intimidation, stalking, bullying or threating behaviour and lanuague (as well as actualy threats);
+- Public or private harassment, intimidation, stalking, bullying or threating behaviour and language (as well as actually threats);
 - Publishing (or the threat of publishing) others' private and personally identifying information, such as a physical or electronic address, without explicit permission ("doxing");
 - Other conduct which could reasonably be considered inappropriate in a professional setting.
 
@@ -45,9 +46,9 @@ We have also put together some examples of unacceptable behavior, these include:
 
 The gliff.ai team aims to ensure our digital space to be a positive and welcoming environment for all contributors so that we can work on what matters most, making a difference!
 
-As such, the gliff.ai team has the responsibility for clarifying the standards of acceptable behavior (examples above) and will take any appropriate and fair corrective action in response to any instances of unacceptable behavior from contributors. The manner of which will depend on the nature and extent of the behavior.
+As such, the gliff.ai team has the responsibility for clarifying the standards of acceptable behaviour (examples above) and will take any appropriate and fair corrective action in response to any instances of unacceptable behaviour from contributors. The manner of which will depend on the nature and extent of the behaviour.
 
-Ultimately, the gliff.ai team have the right to act quickly, before a full investigation of a report, to minimise the  negative effects. As well as the responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful. 
+Ultimately, the gliff.ai team have the right to act quickly, before a full investigation of a report, to minimise the negative effects. As well as the responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviours that they deem inappropriate, threatening, offensive, or harmful. 
 
 The [gliff.ai Code of Conduct](https://github.com/gliff-ai/.github/blob/main/CODE_OF_CONDUCT.md) ⚠️ does not replace existing legal mechanisms, as such, for any incident where a crime may have been committed we will support the victim and pass on the report with necessary details to the police.
 
@@ -55,11 +56,11 @@ The [gliff.ai Code of Conduct](https://github.com/gliff-ai/.github/blob/main/COD
 
 [{{back to navigation}}](#table-of-contents)
 
-Anyone who is engaging with gliff.ai who
+Anyone who is engaging with gliff.ai who finds or experiences a Code of Conduct violation may report the incident.
 
-Any instances of abusive, harassing, or otherwise unacceptable behavior should be reported by contacting the gliff.ai team at at [community@gliff.ai](mailto:community@gliff.ai?subject=[GitHub%20-%20Conduct%20Report]) or on GitHub. Written documentation is our prefered manner to begin the process of documenting evidence. Any reports will be reviewed and investigated as part of our pledge to protect our safe and welcoming environment. As such, we will always maintain confidentiality with regards to the reporter of an incident. Any response given will be considered necessary and appropriate to the report raised to the team.
+Any instances of abusive, harassing, or otherwise unacceptable behaviour should be reported by contacting the gliff.ai team at [community@gliff.ai](mailto:community@gliff.ai?subject=[GitHub%20-%20Conduct%20Report]) or on GitHub. Written documentation is our preferred manner to begin the process of documenting evidence. Any reports will be reviewed and investigated as part of our pledge to protect our safe and welcoming environment. As such, we will always maintain confidentiality with regards to the reporter of an incident. Any response given will be considered necessary and appropriate to the report raised to the team.
 
-Any gliff.ai team members who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions. This will be judged and a response will be determined by other members of the gliff.ai team leadership.
+Any gliff.ai team members who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions. This will be judged, and a response will be determined by other members of the gliff.ai team leadership.
 
 ## Contact
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,61 @@
+# gliff.ai Code of Conduct
+
+⚠️ **All projects and contributors are governed by this document!** ⚠️
+
+&nbsp;  
+The purpose of this guide is to ensure all contributors and projects within the gliff.ai space have a unified Code of Conduct to create a positive and welcoming environment for all.
+
+## Table of Contents
+
+Looking for something specific? 🔍
+
+- [Introduction](#gliffai-security-policy)
+- [Our Standards](#supported-versions)
+- [Our Responsibilities](#report-a-vulnerability)
+- [Enforcement](#response)
+- [Contact](#contact)
+
+## Our Standards
+
+[{{back to navigation}}](#table-of-contents)
+
+We have put together some examples of behavior that contributes to creating a positive and welcoming environment, these include:
+
+- Using welcoming and inclusive language;
+- Being respectful of differing viewpoints, experiences and skill levels;
+- Gracefully accepting constructive criticism;
+- Focusing on what is best for the community and users;
+- Showing empathy towards other community members.
+
+We have also put together some examples of unacceptable behavior by contributors, these include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances;
+- Trolling, insulting/derogatory comments, and personal or political attacks;
+- Public or private harassment;
+- Publishing others' private information, such as a physical or electronic address, without explicit permission;
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Our Responsibilites
+
+[{{back to navigation}}](#table-of-contents)
+
+The gliff.ai team aims to ensure our digital space to be a positive and welcoming environment for all contributors so that we can work on what matters most!
+
+As such, the gliff.ai team has the responsibility for clarifying the standards of acceptable behavior (examples above) and will take any appropriate and fair corrective action in response to any instances of unacceptable behavior from contributors.
+
+Ultimately, the gliff.ai team have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful. 
+
+## Enforcement
+
+[{{back to navigation}}](#table-of-contents)
+
+If you come across any instances of abusive, harassing, or otherwise unacceptable behavior you should report it by contacting the gliff.ai team at at [contact@gliff.ai](mailto:contact@gliff.ai?subject=[GitHub%20-%20Conduct]) or on GitHub. Any complaints will be reviewed and investigated as part of our pledge to protect our positive and welcoming environment. As such, we will always maintain confidentiality with regards to the reporter of an incident. Any response given will be considered necessary and appropriate to the report raised to the team.
+
+Any gliff.ai team members who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions. This will be judged and a response will be determined by other members of the gliff.ai team leadership.
+
+## Contact
+
+[{{back to navigation}}](#table-of-contents)
+
+Have a question? 🧠 Want to report something? 🚨 \
+Reach out to the gliff.ai team at [contact@gliff.ai](mailto:contact@gliff.ai?subject=[GitHub%20-%20Conduct]) or on GitHub.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -48,7 +48,7 @@ Ultimately, the gliff.ai team have the right and responsibility to remove, edit,
 
 [{{back to navigation}}](#table-of-contents)
 
-If you come across any instances of abusive, harassing, or otherwise unacceptable behavior you should report it by contacting the gliff.ai team at at [contact@gliff.ai](mailto:contact@gliff.ai?subject=[GitHub%20-%20Conduct]) or on GitHub. Any complaints will be reviewed and investigated as part of our pledge to protect our positive and welcoming environment. As such, we will always maintain confidentiality with regards to the reporter of an incident. Any response given will be considered necessary and appropriate to the report raised to the team.
+If you come across any instances of abusive, harassing, or otherwise unacceptable behavior you should report it by contacting the gliff.ai team at at [community@gliff.ai](mailto:community@gliff.ai?subject=[GitHub%20-%20Conduct]) or on GitHub. Any complaints will be reviewed and investigated as part of our pledge to protect our positive and welcoming environment. As such, we will always maintain confidentiality with regards to the reporter of an incident. Any response given will be considered necessary and appropriate to the report raised to the team.
 
 Any gliff.ai team members who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions. This will be judged and a response will be determined by other members of the gliff.ai team leadership.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,8 +6,6 @@ The purpose of this guide is to outline [gliff.ai](https://gliff.ai)'s expectati
 
 [gliff.ai](https://gliff.ai) employees a team of passionate and innovative backgrounds, with the outlook that our compnay, our products and our customers benefit from diveristy of backgrounds and perspectives. We prioritise creating a space which is a safe and welcoming environment for all, regardless of their personal identity or background, as anything other than thise can jeopardise the ability to work and with [gliff.ai](https://gliff.ai).
 
-The [gliff.ai Code of Conduct](https://github.com/gliff-ai/.github/blob/main/CODE_OF_CONDUCT.md) ⚠️ **DOES NOT** replace existing legal mechanisms.
-
 ## Table of Contents
 
 Looking for something specific? 🔍
@@ -22,37 +20,44 @@ Looking for something specific? 🔍
 
 [{{back to navigation}}](#table-of-contents)
 
+gliff.ai understands that, in upsetting or distressing circumstances, and in certain forms or stages of ill health, people may act out of character and may become persistent, angry or upset. However, where it leads to aggressive behaviour or unreasonable demands, it is considered unacceptable. Similarly, behaviour which disrupts normal gliff.ai activities, intentionally or not, is considered unacceptable. gliff.ai considers that all forms of harassment constitute unacceptable behaviour.
+
 We have put together some examples of behavior that contributes to creating a positive and welcoming environment, these include:
 
 - Using welcoming and inclusive language;
-- Being respectful of differing viewpoints, experiences and skill levels;
+- Being respectful of differing viewpoints, experiences and skill/ability levels;
 - Gracefully accepting constructive criticism;
 - Focusing on what is best for the community and users;
-- Showing empathy towards other community members.
+- Showing empathy and respect towards other community members.
 
-We have also put together some examples of unacceptable behavior by contributors, these include:
+We have also put together some examples of unacceptable behavior, these include:
 
 - The use of sexualized language or imagery and unwelcome sexual attention or advances;
-- Trolling, insulting/derogatory comments, and personal or political attacks;
-- Public or private harassment;
-- Publishing others' private information, such as a physical or electronic address, without explicit permission;
+- Comments that reinforce social structures of domination and/or discrimination realted to gender, gender identity and expression, sexual orientation, ability, physical appear, race and ethnicity, religion and believe or other ireelevant distinctions;
+- Trolling, spamming, insulting/derogatory comments, and personal or political attacks;
+- Public or private harassment, intimidation, stalking, bullying or threating behaviour and lanuague (as well as actualy threats);
+- Publishing (or the threat of publishing) others' private and personally identifying information, such as a physical or electronic address, without explicit permission ("doxing");
 - Other conduct which could reasonably be considered inappropriate in a professional setting.
 
 ## Our Responsibilites
 
 [{{back to navigation}}](#table-of-contents)
 
-The gliff.ai team aims to ensure our digital space to be a positive and welcoming environment for all contributors so that we can work on what matters most!
+The gliff.ai team aims to ensure our digital space to be a positive and welcoming environment for all contributors so that we can work on what matters most, making a difference!
 
-As such, the gliff.ai team has the responsibility for clarifying the standards of acceptable behavior (examples above) and will take any appropriate and fair corrective action in response to any instances of unacceptable behavior from contributors.
+As such, the gliff.ai team has the responsibility for clarifying the standards of acceptable behavior (examples above) and will take any appropriate and fair corrective action in response to any instances of unacceptable behavior from contributors. The manner of which will depend on the nature and extent of the behavior.
 
-Ultimately, the gliff.ai team have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful. 
+Ultimately, the gliff.ai team have the right to act quickly, before a full investigation of a report, to minimise the  negative effects. As well as the responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful. 
+
+The [gliff.ai Code of Conduct](https://github.com/gliff-ai/.github/blob/main/CODE_OF_CONDUCT.md) ⚠️ does not replace existing legal mechanisms, as such, for any incident where a crime may have been committed we will support the victim and pass on the report with necessary details to the police.
 
 ## Enforcement
 
 [{{back to navigation}}](#table-of-contents)
 
-If you come across any instances of abusive, harassing, or otherwise unacceptable behavior you should report it by contacting the gliff.ai team at at [community@gliff.ai](mailto:community@gliff.ai?subject=[GitHub%20-%20Conduct%20Report]) or on GitHub. Any complaints will be reviewed and investigated as part of our pledge to protect our positive and welcoming environment. As such, we will always maintain confidentiality with regards to the reporter of an incident. Any response given will be considered necessary and appropriate to the report raised to the team.
+Anyone who is engaging with gliff.ai who
+
+Any instances of abusive, harassing, or otherwise unacceptable behavior should be reported by contacting the gliff.ai team at at [community@gliff.ai](mailto:community@gliff.ai?subject=[GitHub%20-%20Conduct%20Report]) or on GitHub. Written documentation is our prefered manner to begin the process of documenting evidence. Any reports will be reviewed and investigated as part of our pledge to protect our safe and welcoming environment. As such, we will always maintain confidentiality with regards to the reporter of an incident. Any response given will be considered necessary and appropriate to the report raised to the team.
 
 Any gliff.ai team members who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions. This will be judged and a response will be determined by other members of the gliff.ai team leadership.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,10 +8,10 @@ The purpose of this guide is to ensure all contributors and projects within the 
 
 Looking for something specific? 🔍
 
-- [Introduction](#gliffai-security-policy)
-- [Our Standards](#supported-versions)
-- [Our Responsibilities](#report-a-vulnerability)
-- [Enforcement](#response)
+- [Introduction](#gliffai-code-of-conduct)
+- [Our Standards](#our-standards)
+- [Our Responsibilities](#our-responsibilities)
+- [Enforcement](#enforcement)
 - [Contact](#contact)
 
 ## Our Standards

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,6 @@
 
 ⚠️ **All projects and contributors are governed by this document!** ⚠️
 
-&nbsp;  
 The purpose of this guide is to ensure all contributors and projects within the gliff.ai space have a unified Code of Conduct to create a positive and welcoming environment for all.
 
 ## Table of Contents

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ⚠️ **All projects and contributors are governed by this document!** ⚠️
 
-The purpose of this guide is to ensure all contributors and projects within the gliff.ai space have a unified Code of Conduct to create a positive and welcoming environment for all.
+The purpose of this guide is to ensure all contributors and projects within the [gliff.ai](https://gliff.ai) space have a unified Code of Conduct to create a positive and welcoming environment for all.
 
 ## Table of Contents
 


### PR DESCRIPTION
## Description

Large documentation addition of CODE_OF_CONDUCT.md which improves the gliff.ai GitHub Community Health Files. 

*(note: file name uses `_` instead of `-` to meet GitHub's requested format which also allows for the documentation to be recognised by the system)