### PR TITLE
chore: fix missing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The [gliff.ai](https://gliff.ai) GITHUB COMMUNITY HEALTH FILES aim to foster a p
 Looking for something specific? 🔍
 
  - [Repository Introduction](#gliffai-github-community-health-files)
+ - [Table of Contents](#table-of-contents)
  - [Contribute](#contribute)
  - [Contact](#contact)
 


### PR DESCRIPTION
## Description

Add missing `Table of Contents` link for consistency with other documentation updates.