### PR TITLE
feat: update labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,7 +14,7 @@ labels:
   - label: "dependencies"
     sync: true
     matcher:
-      title: "^build: .*"
+      title: "^build.*"
 
   - label: "test"
     sync: true

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,7 @@
 version: v1
 
 labels:
-  - label: "enhancement"
+  - label: "feature"
     sync: true
     matcher:
       title: "^feat: .*"
@@ -14,7 +14,7 @@ labels:
   - label: "dependencies"
     sync: true
     matcher:
-      title: "^build.*"
+      title: "^build: .*"
 
   - label: "test"
     sync: true


### PR DESCRIPTION
## Description

Update labeler.yml to prevent automatic label conflicting with PR content. Replace `feat:` label from `enhancement` to `feature`.